### PR TITLE
Fix building threadfix lib in MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.dylib
 
 # Distribution / packaging
 .Python

--- a/__PySiddhiProxy/threadfix_c_code/build.sh
+++ b/__PySiddhiProxy/threadfix_c_code/build.sh
@@ -18,7 +18,7 @@ echo "Compiling C++ Code used for fixing threading issue"
 echo "Invoking G++ Compiler"
 
 if [["$OSTYPE" == "darwin"*]]; then
-    g++ -I "$JAVA_HOME/include" -I "$JAVA_HOME/include/darwin" -I "$PYTHONHOME" -shared -fPIC -o libio_siddhi_pythonapi_threadfix_pythreadfix.so io_siddhi_pythonapi_threadfix_PyThreadFix.c
+    g++ -I "$JAVA_HOME/include" -I "$JAVA_HOME/include/darwin" -I "$PYTHONHOME" -shared -flat_namespace -undefined suppress -dynamiclib -o libio_siddhi_pythonapi_threadfix_pythreadfix.so io_siddhi_pythonapi_threadfix_PyThreadFix.c
 elif [["$OSTYPE" == "linux-gnu"]]; then
     g++ -I "$JAVA_HOME/include" -I "$JAVA_HOME/include/linux" -I "$PYTHONHOME" -shared -fPIC -o libio_siddhi_pythonapi_threadfix_pythreadfix.so io_siddhi_pythonapi_threadfix_PyThreadFix.c
 fi

--- a/__PySiddhiProxy/threadfix_c_code/makefile
+++ b/__PySiddhiProxy/threadfix_c_code/makefile
@@ -16,8 +16,6 @@
 # use g++ compiler
 CC = g++
 
-CFLAGS =-shared -fPIC -c
-
 # define JAVA_HOME here
 JAVAHOME = ${JAVA_HOME}
 
@@ -31,13 +29,15 @@ OS = ${shell uname}
 
 CP = cp
 
-#Find include files
-INCLUDES_LINUX = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/linux" -I "$(LINUX_PYTHON_PATH)"
-
-INCLUDES_MACOS = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/darwin" -I "$(MACOS_PYTHON_PATH)"
-
-
-
+ifeq ($(OS), Darwin)
+CFLAGS = -shared -flat_namespace -undefined suppress -dynamiclib
+INCLUDES = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/darwin" -I "$(MACOS_PYTHON_PATH)"
+OUT_EXT = dylib
+else
+CFLAGS = -shared -fPIC
+INCLUDES = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/linux" -I "$(LINUX_PYTHON_PATH)"
+OUT_EXT = so
+endif
 
 # build target details
 TARGET_SOURCE_NAME = io_siddhi_pythonapi_threadfix_PyThreadFix
@@ -47,19 +47,15 @@ TARGET = threadfix
 
 all: install
 
-$(TARGET_OUTPUT_NAME).so: $(TARGET_SOURCE_NAME).c $(TARGET_SOURCE_NAME).h
+$(TARGET_OUTPUT_NAME).$(OUT_EXT): $(TARGET_SOURCE_NAME).c $(TARGET_SOURCE_NAME).h
 	@echo "Building Target..."
-ifeq ($(OS), Darwin)
-	$(CC) $(CFLAGS) $(INCLUDES_MACOS) -o $(TARGET_OUTPUT_NAME).so $(TARGET_SOURCE_NAME).c
-else ifeq ($(OS), Linux)
-	$(CC) $(CFLAGS) $(INCLUDES_LINUX) -o $(TARGET_OUTPUT_NAME).so $(TARGET_SOURCE_NAME).c
-endif
+	$(CC) $(CFLAGS) $(INCLUDES) -o $(TARGET_OUTPUT_NAME).$(OUT_EXT) $(TARGET_SOURCE_NAME).c
 	@echo
 
-install: $(TARGET_OUTPUT_NAME).so
+install: $(TARGET_OUTPUT_NAME).$(OUT_EXT)
 	@echo "Copying Target to Root..."
-	$(CP) $(TARGET_OUTPUT_NAME).so ../$(TARGET_INSTALL_NAME).so
+	$(CP) $(TARGET_OUTPUT_NAME).$(OUT_EXT) ../$(TARGET_INSTALL_NAME).$(OUT_EXT)
 	@echo
 
 clean:
-	$(RM) $(TARGET_OUTPUT_NAME).so
+	$(RM) $(TARGET_OUTPUT_NAME).$(OUT_EXT)

--- a/__PySiddhiProxy/threadfix_c_code/makefile
+++ b/__PySiddhiProxy/threadfix_c_code/makefile
@@ -16,7 +16,7 @@
 # use g++ compiler
 CC = g++
 
-CFLAGS = -shared -fPIC
+CFLAGS =-shared -fPIC -c
 
 # define JAVA_HOME here
 JAVAHOME = ${JAVA_HOME}
@@ -34,7 +34,7 @@ CP = cp
 #Find include files
 INCLUDES_LINUX = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/linux" -I "$(LINUX_PYTHON_PATH)"
 
-INCLUDES_MACOS = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/darwin" -I "$(MACOS_PYTHON_PATH)
+INCLUDES_MACOS = -I "$(JAVAHOME)/include" -I "$(JAVAHOME)/include/darwin" -I "$(MACOS_PYTHON_PATH)"
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(
     package_data={
         "PySiddhi": ["../__PySiddhiProxy/target/lib/*.jar",
                       "../__PySiddhiProxy/target/*.jar",
-                      "../__PySiddhiProxy/*.so"]
+                      "../__PySiddhiProxy/*.so",
+                      "../__PySiddhiProxy/*.dylib"]
     },
 
     # metadata for upload to PyPI

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     name="PySiddhi",
     version="5.0.0",
     packages=filtered_packages,
-    python_requires='>=2.7, ~=3.7',
+    python_requires='>=2.7, >=3.6',
     install_requires=["requests","pyjnius", "future", "enum34 ; python_version<'4'"],
     package_data={
         "PySiddhi": ["../__PySiddhiProxy/target/lib/*.jar",


### PR DESCRIPTION
## Purpose
In the current build scripts for `threadfix` lib, a `.so` file is getting generated as the result. But in MacOS, `System.loadLibrary()` method cannot load `.so` files, instead it requires `.dylib` file. This PR modifies the build scripts to generate `.dylib` files in MacOS environment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes