### PR TITLE
Bump Siddhi version and fix test failure

### DIFF
--- a/Tests/SiddhiCoreTests/TestOutputStream.py
+++ b/Tests/SiddhiCoreTests/TestOutputStream.py
@@ -44,8 +44,7 @@ class TestOutputStream(TestCase):
     def test_outputstram(self):
         logging.info("OutputStream Test 1: Test reception of events")
         siddhiManager = SiddhiManager()
-        cseEventStream = "@config(async = 'true') " \
-                         "define stream cseEventStream (symbol string, price float, volume int);"
+        cseEventStream = "define stream cseEventStream (symbol string, price float, volume int);"
 
         query = "@info(name = 'query 1') from cseEventStream select symbol, price, volume insert into OutputStream; "
 
@@ -58,6 +57,7 @@ class TestOutputStream(TestCase):
                 _self_shaddow.inEventCount.addAndGet(len(events))
 
         siddhiAppRuntime.addCallback("OutputStream", StreamCallbackImpl())
+        siddhiAppRuntime.start()
 
         inputHandler = siddhiAppRuntime.getInputHandler("cseEventStream")
 

--- a/__PySiddhiProxy/pom.xml
+++ b/__PySiddhiProxy/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>io.siddhi</groupId>
             <artifactId>siddhi-core</artifactId>
-            <version>5.1.5</version>
+            <version>5.1.7</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Purpose
This PR bumps the Siddhi version to 5.1.7 and fixes a test failure.

Resolves https://github.com/siddhi-io/PySiddhi/issues/30

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes